### PR TITLE
Typo fix: `cacllback` -> `callback`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ new FgTinyEditor({
     </div>
 </div>
 ```
-When inserting individual tools, cacllback must be declared inside initialization object, inside **inlineFunctions** object
+When inserting individual tools, callback must be declared inside initialization object, inside **inlineFunctions** object
 ```
 new FgTinyEditor({
     selector: '.editable',


### PR DESCRIPTION
Fixing small typo in `README.md` file: `cacllback` -> `callback`